### PR TITLE
refine Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,38 +57,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
-name = "i18n-locale-lint-ast"
+name = "i18n_locale_lint_ast"
 version = "0.1.2"
 dependencies = [
  "itertools",
 ]
 
 [[package]]
-name = "i18n-locale-lint-cli"
+name = "i18n_locale_lint_cli"
 version = "0.1.2"
 dependencies = [
  "getopts",
- "i18n-locale-lint-ast",
- "i18n-locale-lint-json",
- "i18n-locale-lint-yaml",
+ "i18n_locale_lint_ast",
+ "i18n_locale_lint_json",
+ "i18n_locale_lint_yaml",
  "once_cell",
  "regex",
 ]
 
 [[package]]
-name = "i18n-locale-lint-json"
+name = "i18n_locale_lint_json"
 version = "0.1.2"
 dependencies = [
- "i18n-locale-lint-ast",
+ "i18n_locale_lint_ast",
  "insta",
  "serde_json",
 ]
 
 [[package]]
-name = "i18n-locale-lint-yaml"
+name = "i18n_locale_lint_yaml"
 version = "0.1.2"
 dependencies = [
- "i18n-locale-lint-ast",
+ "i18n_locale_lint_ast",
  "insta",
  "serde_yaml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,10 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
-name = "i18n-locale-lint"
-version = "0.1.2"
-
-[[package]]
 name = "i18n-locale-lint-ast"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,8 @@
-[package]
-name = "i18n-locale-lint"
-version = "0.1.2"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [workspace]
 resolver = "2"
 members = [
-    "crates/ast",
-    "crates/cli",
-    "crates/json",
-    "crates/yaml",
+    "crates/*",
 ]
-
-[lib]
-path = "./crates/cli"
-crate-type = ["cdylib", "rlib"]
 
 [profile.release]
 strip = true

--- a/bin/main.mjs
+++ b/bin/main.mjs
@@ -14,7 +14,7 @@ const wasi = new WASI({
   },
 });
 
-const url = new URL("../wasm/i18n-locale-lint-cli.wasm", import.meta.url);
+const url = new URL("../wasm/i18n_locale_lint_cli.wasm", import.meta.url);
 const wasm = await WebAssembly.compile(fs.readFileSync(url));
 const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
 const instance = await WebAssembly.instantiate(wasm, importObject);

--- a/build/build.sh
+++ b/build/build.sh
@@ -13,4 +13,4 @@ rm -rf wasm
 cargo wasi build $TAG || { echo "build failed"; exit 1; }
 
 mkdir -p wasm
-mv ./target/wasm32-wasi/$TARGET_DIR/i18n-locale-lint-cli.wasm wasm/i18n-locale-lint-cli.wasm
+mv ./target/wasm32-wasi/$TARGET_DIR/i18n_locale_lint_cli.wasm wasm/i18n_locale_lint_cli.wasm

--- a/build/build.sh
+++ b/build/build.sh
@@ -10,9 +10,7 @@ fi
 echo $TARGET_DIR build
 
 rm -rf wasm
-(
-    cd crates/cli
-    cargo wasi build $TAG
-)
+cargo wasi build $TAG || { echo "build failed"; exit 1; }
+
 mkdir -p wasm
 mv ./target/wasm32-wasi/$TARGET_DIR/i18n-locale-lint-cli.wasm wasm/i18n-locale-lint-cli.wasm

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RELEASE=true sh build/build.sh
+RELEASE=true sh build/build.sh || { exit 1; }
 
 echo run "npm pack"
 npm pack

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "i18n-locale-lint-ast"
+name = "i18n_locale_lint_ast"
 version = "0.1.2"
 edition = "2021"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "i18n-locale-lint-cli"
+name = "i18n_locale_lint_cli"
 version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-i18n-locale-lint-ast = { path = "../ast" }
-i18n-locale-lint-json = { path = "../json" }
-i18n-locale-lint-yaml = { path = "../yaml" }
+i18n_locale_lint_ast = { path = "../ast" }
+i18n_locale_lint_json = { path = "../json" }
+i18n_locale_lint_yaml = { path = "../yaml" }
 getopts = "0.2"
 once_cell = "1.19.0"
 regex = "1.10.4"

--- a/crates/json/Cargo.toml
+++ b/crates/json/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "i18n-locale-lint-json"
+name = "i18n_locale_lint_json"
 version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-i18n-locale-lint-ast = { path = "../ast" }
+i18n_locale_lint_ast = { path = "../ast" }
 serde_json = "1.0.113"
 
 [dev-dependencies]

--- a/crates/yaml/Cargo.toml
+++ b/crates/yaml/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "i18n-locale-lint-yaml"
+name = "i18n_locale_lint_yaml"
 version = "0.1.2"
 edition = "2021"
 
 [dependencies]
-i18n-locale-lint-ast = { path = "../ast" }
+i18n_locale_lint_ast = { path = "../ast" }
 serde_yaml = "0.9.34"
 
 [dev-dependencies]


### PR DESCRIPTION
- rename all the rust packages by replacing "-" to "_"
- remove `[package]` table from the root Cargo.toml to run `cargo build` at the root
- update build script by make the process exit when one of the steps fails