### PR TITLE
add `group-size`  option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Or if you define an npm script with this library, it's recommended to enclose th
 | `--silent`         | `-s`       | Don't display logs other than errors.                                         |
 | `--skip-top-level` |            | Assuming the top level is composed solely of a single key, skip it.           |
 | `--grouped-by`     | `-g`       | Group locale file by a regular expression. (`-g "^(.*/)([^/]+)$"` by default) |
+| `--group-size`     |            | If it is specified, fails when the size of a group is not equal to it.        |

--- a/crates/cli/src/check.rs
+++ b/crates/cli/src/check.rs
@@ -32,6 +32,22 @@ fn read_json_file(path: &str) -> Result<Value, CliError> {
 }
 
 pub fn check(file_paths: &Vec<&str>) -> i32 {
+    if let Some(expected_size) = option::INSTANCE.get().unwrap().group_size {
+        let actual_size = file_paths.len();
+        if actual_size != expected_size {
+            eprintln!("comparing:");
+            for path in file_paths {
+                eprintln!("- {}", path);
+            }
+
+            display_error(CliError::MismatchedGroupSizeError(
+                expected_size,
+                actual_size,
+            ));
+            return 1;
+        }
+    }
+
     if file_paths.len() <= 1 {
         return 0;
     }

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -5,6 +5,7 @@ pub enum CliError<'a> {
     FileReadError(Error),
     ParseError(&'a str, String),
     SkipTopLevelError(String),
+    MismatchedGroupSizeError(usize, usize),
 }
 
 impl<'a> Display for CliError<'a> {
@@ -23,6 +24,13 @@ impl<'a> Display for CliError<'a> {
             }
             CliError::SkipTopLevelError(message) => {
                 write!(f, "{}", message)
+            }
+            CliError::MismatchedGroupSizeError(expected, actual) => {
+                write!(
+                    f,
+                    "expected the group size to be {}, but it was actually {}.",
+                    expected, actual
+                )
             }
         }
     }

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -8,6 +8,7 @@ pub struct CliOption {
     pub silent: bool,
     pub skip_top_level: bool,
     pub grouped_by: Option<String>,
+    pub group_size: Option<u8>,
 }
 pub static INSTANCE: OnceCell<CliOption> = OnceCell::new();
 
@@ -39,6 +40,12 @@ impl CliOption {
             "Group locale file by a regular expression. (`-g \"^(.*/)([^/]+)$\"` by default)",
             "",
         );
+        opts.optopt(
+            "",
+            "group-size",
+            "If it is specified, fails when the size of a group is not equal to it.",
+            "",
+        );
 
         let matches = match opts.parse(args) {
             Ok(m) => m,
@@ -58,6 +65,10 @@ impl CliOption {
         if let Some(g) = matches.opt_str("grouped-by") {
             grouped_by = Option::Some(g);
         }
+        let group_size = matches.opt_str("group_size").map(|s| {
+            s.parse::<u8>()
+                .unwrap_or_else(|_| panic!("invalid group_size value: {}", s))
+        });
 
         let free = matches.free.clone();
         let files: Vec<OsString> = match free.len() {
@@ -83,6 +94,7 @@ impl CliOption {
             silent,
             skip_top_level,
             grouped_by,
+            group_size,
         }
     }
 }

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -8,7 +8,7 @@ pub struct CliOption {
     pub silent: bool,
     pub skip_top_level: bool,
     pub grouped_by: Option<String>,
-    pub group_size: Option<u8>,
+    pub group_size: Option<usize>,
 }
 pub static INSTANCE: OnceCell<CliOption> = OnceCell::new();
 
@@ -66,7 +66,7 @@ impl CliOption {
             grouped_by = Option::Some(g);
         }
         let group_size = matches.opt_str("group_size").map(|s| {
-            s.parse::<u8>()
+            s.parse::<usize>()
                 .unwrap_or_else(|_| panic!("invalid group_size value: {}", s))
         });
 

--- a/crates/cli/src/option.rs
+++ b/crates/cli/src/option.rs
@@ -65,7 +65,7 @@ impl CliOption {
         if let Some(g) = matches.opt_str("grouped-by") {
             grouped_by = Option::Some(g);
         }
-        let group_size = matches.opt_str("group_size").map(|s| {
+        let group_size = matches.opt_str("group-size").map(|s| {
             s.parse::<usize>()
                 .unwrap_or_else(|_| panic!("invalid group_size value: {}", s))
         });

--- a/examples/failure/package.json
+++ b/examples/failure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18n-locale-lint-example-failure",
   "scripts": {
-    "i18n-lint": "i18n-locale-lint src/locale/**/*.json"
+    "i18n-lint": "i18n-locale-lint src/locale/**/*.json --group-size 2"
   },
   "devDependencies": {
     "i18n-locale-lint": "*"

--- a/examples/success/package.json
+++ b/examples/success/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18n-locale-lint-example-success",
   "scripts": {
-    "i18n-lint": "i18n-locale-lint src/locale/**/*.json"
+    "i18n-lint": "i18n-locale-lint src/locale/**/*.json --group-size 2"
   },
   "devDependencies": {
     "i18n-locale-lint": "*"

--- a/examples/yaml/package.json
+++ b/examples/yaml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "i18n-locale-lint-example-yaml",
   "scripts": {
-    "i18n-lint": "i18n-locale-lint \"src/locale/**/*.yml\" --skip-top-level"
+    "i18n-lint": "i18n-locale-lint \"src/locale/**/*.yml\" --skip-top-level --group-size 2"
   },
   "devDependencies": {
     "i18n-locale-lint": "*"


### PR DESCRIPTION
add `--group-size` to specify the expected group size. If the actual size of any group is different than it, the process fails